### PR TITLE
Bump smarty to min >3.1.44

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     },
     "require": {
-        "smarty/smarty": ">3.1.44 || ^4.0",
+        "smarty/smarty": "^3.1.45 || ^4.0",
         "php": ">=7.3"
     },
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         }
     },
     "require": {
-        "smarty/smarty": "~3.1 || ~4.0",
+        "smarty/smarty": ">3.1.44 || ^4.0",
         "php": ">=7.3"
     },
     "keywords": [


### PR DESCRIPTION
This will prevent CVE-2022-29221 (High) in smarty/smarty-v3.1.44